### PR TITLE
Update bigdecimal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     intrinio-realtime (5.0.0)
-      bigdecimal (~> 1.4.0)
+      bigdecimal (~> 2.0.0)
       eventmachine (~> 1.2)
       thread (~> 0.2.2)
       websocket-client-simple (~> 0.3)
@@ -10,8 +10,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (1.4.4)
+    bigdecimal (2.0.3)
     event_emitter (0.2.6)
+    eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     thread (0.2.2)
     websocket (1.2.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     eventmachine (1.2.7-x64-mingw32)
     thread (0.2.2)
     websocket (1.2.9)
-    websocket-client-simple (0.3.0)
+    websocket-client-simple (0.6.1)
       event_emitter
       websocket
 

--- a/intrinio-realtime.gemspec
+++ b/intrinio-realtime.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "eventmachine", '~> 1.2'
   spec.add_dependency "websocket-client-simple", '~> 0.3'
   spec.add_dependency "thread", '~> 0.2.2'
-  spec.add_dependency "bigdecimal", '~> 1.4.0'
+  spec.add_dependency "bigdecimal", '~> 2.0.0'
 end


### PR DESCRIPTION
Update big decimal to get rid of deprecation warnings related to ruby 3.0 in versions of bigdecimal < 2.0